### PR TITLE
Remove explicit line break from log messages

### DIFF
--- a/R/accumulate_forecast.R
+++ b/R/accumulate_forecast.R
@@ -34,7 +34,7 @@ accumulate_forecast <- function(.fcst, accumulation_time, accumulation_unit, che
   }
 
   if (length(missing_lead_times) > 0 && check_leads) {
-    warning("Not enough lead times to compute accumulation - will try to get more data\n", immediate. = TRUE, call. = FALSE)
+    warning("Not enough lead times to compute accumulation - will try to get more data", immediate. = TRUE, call. = FALSE)
     return(missing_lead_times)
   }
 
@@ -46,7 +46,7 @@ accumulate_forecast <- function(.fcst, accumulation_time, accumulation_unit, che
 
   if (length(lead_times_res) > 1) {
 
-    warning("Lead times are not equally spaced. Accumulating could take some time\n", immediate. = TRUE, call. = FALSE)
+    warning("Lead times are not equally spaced. Accumulating could take some time", immediate. = TRUE, call. = FALSE)
 
     .fcst <- .fcst %>%
       dplyr::mutate(lead_acc = .data$leadtime + accumulation_time)
@@ -102,7 +102,7 @@ accumulate_forecast <- function(.fcst, accumulation_time, accumulation_unit, che
     }
 
     if (nrow(bad_data) > 0) {
-      warning("Some lead times do not have equal amounts of data - doing a slower robust join.\n", immediate. = TRUE, call. = FALSE)
+      warning("Some lead times do not have equal amounts of data - doing a slower robust join.", immediate. = TRUE, call. = FALSE)
       bad_data_lagged <- tidyr::unnest(bad_data, .data$lagged_data) %>%
         dplyr::rename(forecast1 = .data$forecast)
       bad_data <- tidyr::unnest(bad_data, .data$data) %>%

--- a/R/read_grib.R
+++ b/R/read_grib.R
@@ -78,7 +78,7 @@ read_grib_interpolate <- function(file_name, parameter,
   if (file.exists(file_name)) {
     message("Reading: ", file_name)
   } else {
-    warning("File not found: ", file_name, "\n", call. = FALSE, immediate. = TRUE)
+    warning("File not found: ", file_name, call. = FALSE, immediate. = TRUE)
     return(empty_data)
   }
 

--- a/R/read_vfile.R
+++ b/R/read_vfile.R
@@ -25,7 +25,7 @@ read_vfile <- function(
   v_metadata   <- scan(file_connection, nlines = 1, quiet = TRUE)
 
   if (length(v_metadata) < 2 | length(v_metadata) > 3) {
-    warning("Unable to read: ", v_file_name, "\n", call. = FALSE, immediate. = TRUE)
+    warning("Unable to read: ", v_file_name, call. = FALSE, immediate. = TRUE)
     close(file_connection)
     return(list(synop_data = empty_data, temp_data = empty_data))
   }
@@ -41,7 +41,7 @@ read_vfile <- function(
   }
 
   if (v_version < 2 | v_version > 4) {
-    warning("Unable to read: ", v_file_name, "\nv version = ", v_version, "\n", call. = FALSE, immediate. = TRUE)
+    warning("Unable to read: ", v_file_name, "\nv version = ", v_version, call. = FALSE, immediate. = TRUE)
     close(file_connection)
     return(list(synop_data = empty_data, temp_data = empty_data))
   }

--- a/R/read_vfld_interpolate.R
+++ b/R/read_vfld_interpolate.R
@@ -53,7 +53,7 @@ read_vfld_interpolate <- function(
   if (file.exists(file_name)) {
     message("Reading: ", file_name)
   } else {
-    warning("File not found: ", file_name, "\n", call. = FALSE, immediate. = TRUE)
+    warning("File not found: ", file_name, call. = FALSE, immediate. = TRUE)
     return(empty_data)
   }
 

--- a/R/save_point_verif.R
+++ b/R/save_point_verif.R
@@ -43,7 +43,7 @@ save_point_verif <- function(
     dir.create(dirname(file_name), recursive = TRUE, mode = "0750")
   }
 
-  message("Saving point verification scores to: \n", file_name)
+  message("Saving point verification scores to: ", file_name)
 
   saveRDS(verif_data, file = file_name)
 

--- a/R/write_fctable_to_sqlite.R
+++ b/R/write_fctable_to_sqlite.R
@@ -35,7 +35,7 @@ write_fctable_to_sqlite <- function(
 
   primary_key <- intersect(primary_key, column_names)
 
-  message("Writing to: ", filename, "\n")
+  message("Writing to: ", filename)
 
   sqlite_db <- dbopen(filename)
 

--- a/R/write_obstable_to_sqlite.R
+++ b/R/write_obstable_to_sqlite.R
@@ -18,7 +18,7 @@ write_obstable_to_sqlite <- function(
   if (!file.exists(file_name)) {
     newfile <- TRUE
     if (!dir.exists(dirname(file_name))) dir.create(dirname(file_name), recursive = TRUE, mode = "0750")
-    message("\n***\nNew SQLITE obs file created: ", file_name, "\n***\n")
+    message("\n***\nNew SQLITE obs file created: ", file_name, "\n***")
   }
 
   col_names    <- colnames(obs_data)
@@ -35,7 +35,7 @@ write_obstable_to_sqlite <- function(
     params_types <- gsub("NUMERIC", "REAL", params_types)
   }
 
-  message("Writing to: ", table_name, " in ", file_name, "\n")
+  message("Writing to: ", table_name, " in ", file_name)
 
   sqlite_db <- dbopen(file_name)
   dbquery(sqlite_db, paste("PRAGMA synchronous =", toupper(synchronous)))


### PR DESCRIPTION
message() and warning() supply their own line brake,
so remove any explicit '\n' from log messages to make
logs cleaner.