### PR TITLE
Bug fix to read ECMWF deterministic grib-files

### DIFF
--- a/R/read_grib.R
+++ b/R/read_grib.R
@@ -104,16 +104,12 @@ read_grib <- function(
     multi = format_opts[["multi"]]
   )
 
-  print("FW: grib_info")
-  print(grib_info)
-  print(grib_info[["dataType"]])
   # ecmwf uses local table even for deterministc run. So it includes perturbationNumber=0 for analysis (dataType=2)
-  # and determinstic forecast (dataType=9). We want to get rid of it, otherwise HARP assumes it is an ensemble
+  # and determinstic forecast (dataType=9). We want to get rid of it, otherwise HARP assumes it is an ensemble.
+  # Additional check for dataType is necessary since some local gribfiles do not set dataType.
   if (!is.na(grib_info[["dataType"]]) && (grib_info[["dataType"]] == 9 || grib_info[["dataType"]] == 2 )) {
 	 grib_info[["perturbationNumber"]] <- NA
   }
-  print("FW: grib_info now?")
-  print(grib_info)
 
   grib_file <- grib_info
 

--- a/R/read_grib.R
+++ b/R/read_grib.R
@@ -109,7 +109,7 @@ read_grib <- function(
   print(grib_info[["dataType"]])
   # ecmwf uses local table even for deterministc run. So it includes perturbationNumber=0 for analysis (dataType=2)
   # and determinstic forecast (dataType=9). We want to get rid of it, otherwise HARP assumes it is an ensemble
-  if (grib_info[["dataType"]] != NA && (grib_info[["dataType"]] == 9 || grib_info[["dataType"]] == 2 )) {
+  if (!is.na(grib_info[["dataType"]]) && (grib_info[["dataType"]] == 9 || grib_info[["dataType"]] == 2 )) {
 	 grib_info[["perturbationNumber"]] <- NA
   }
   print("FW: grib_info now?")

--- a/R/read_grib.R
+++ b/R/read_grib.R
@@ -99,10 +99,21 @@ read_grib <- function(
 
   grib_info <- Rgrib2::Gopen(
     file_name,
-    IntPar = c("perturbationNumber", "indicatorOfTypeOfLevel", "paramId"),
+    IntPar = c("perturbationNumber", "indicatorOfTypeOfLevel", "paramId", "dataType"),
     StrPar = "typeOfLevel",
     multi = format_opts[["multi"]]
   )
+
+  print("FW: grib_info")
+  print(grib_info)
+  print(grib_info[["dataType"]])
+  # ecmwf uses local table even for deterministc run. So it includes perturbationNumber=0 for analysis
+  # and determinstic forecast. We want to get rid of it, otherwise HARP assumes it is an ensemble
+  if (grib_info[["dataType"]] == "fc" || grib_info[["dataType"]] == "an" ) {
+	 grib_info[["perturbationNumber"]] <- NA
+  }
+  print("FW: grib_info now?")
+  print(grib_info)
 
   grib_file <- grib_info
 

--- a/R/read_grib.R
+++ b/R/read_grib.R
@@ -109,7 +109,7 @@ read_grib <- function(
   print(grib_info[["dataType"]])
   # ecmwf uses local table even for deterministc run. So it includes perturbationNumber=0 for analysis (dataType=2)
   # and determinstic forecast (dataType=9). We want to get rid of it, otherwise HARP assumes it is an ensemble
-  if (grib_info[["dataType"]] == 9 || grib_info[["dataType"]] == 2 ) {
+  if (grib_info[["dataType"]] != NA && (grib_info[["dataType"]] == 9 || grib_info[["dataType"]] == 2 )) {
 	 grib_info[["perturbationNumber"]] <- NA
   }
   print("FW: grib_info now?")

--- a/R/read_grib.R
+++ b/R/read_grib.R
@@ -107,9 +107,9 @@ read_grib <- function(
   print("FW: grib_info")
   print(grib_info)
   print(grib_info[["dataType"]])
-  # ecmwf uses local table even for deterministc run. So it includes perturbationNumber=0 for analysis
-  # and determinstic forecast. We want to get rid of it, otherwise HARP assumes it is an ensemble
-  if (grib_info[["dataType"]] == "fc" || grib_info[["dataType"]] == "an" ) {
+  # ecmwf uses local table even for deterministc run. So it includes perturbationNumber=0 for analysis (dataType=2)
+  # and determinstic forecast (dataType=9). We want to get rid of it, otherwise HARP assumes it is an ensemble
+  if (grib_info[["dataType"]] == 9 || grib_info[["dataType"]] == 2 ) {
 	 grib_info[["perturbationNumber"]] <- NA
   }
   print("FW: grib_info now?")


### PR DESCRIPTION
### Problem

ECMWF uses a local definition in their grib header where eg. perturbationNumber is specified. This is also the case for deterministic forecasts where perturbationNumber is set to 0. However HARP reads this specific key and if it is set, it assumes to work on ensemble data with perturbationNumber=0 and sets the model name accordingly in the dataframe.

eg. running read_forecasts on gribfile with ECMWF-determinstic forecasts:
![image](https://user-images.githubusercontent.com/89453598/173789559-d0a0107b-b92c-42f0-8c03-7715e658adf3.png)

results in the following output:
![image](https://user-images.githubusercontent.com/89453598/173788225-5d69fd63-8795-4903-a421-1545c7d15bf7.png)

### Solution
The bug fix adds an additional check for the dataType in the grib-header and if it is fc/an (values 9/2) then perturbationNumber is set to NA. Some Centres might not set dataType at all, so there is also a check for dataType=NA, when the check for dataType-value is skipped.
The output of the same read_forecast statement as above now looks like:
![image](https://user-images.githubusercontent.com/89453598/173789241-1c6c805e-3a9c-4136-8bc7-8f5e12aa5c4a.png)

I also checked the code on our local grib-files and on ECMWF-ensemble data. The output looked as expected.

